### PR TITLE
新增acg站点适配

### DIFF
--- a/sites/acg.yml
+++ b/sites/acg.yml
@@ -1,0 +1,108 @@
+id: acgrip
+name: acg
+domain: https://acg.rip
+encoding: UTF-8
+config_url: https://ghproxy.com/https://raw.githubusercontent.com/lovebeefcat/movie-bot-conf/main/sites/acg.yml
+
+login:
+  required: false
+  test:
+    selector: a[id="user-logout"]
+
+category_mappings:
+  - { id: 1, cate_level1: Anime, cate_level2: TV/Anime, cate_level2_desc: "Anime(動畫)" }
+
+userinfo:
+  constant: true
+  fields:
+    uid: 0
+    user_group: ''
+    username: 'acg'
+    share_ratio: ''
+    uploaded: 0
+    downloaded: 0
+    seeding: 0
+    leeching: 0
+    vip_group: 0
+list:
+  path: /1
+  list:
+    selector: div.container > table.table.table-hover.table-condensed.post-index > tr
+  fields:
+    id:
+      selector: td.title > span > a[href^="/t/"]
+      attribute: href
+      filters:
+        - name: re_search
+          args: [ '\d+', 0 ]
+    category:
+      default_value: 1
+    details:
+      selector: td.title > span > a[href^="/t/"]
+      attribute: href
+    download:
+      selector: td.action > a[href^="/t/"]
+      attribute: href
+    size:
+      selector: td.size
+    grabs:
+      default_value: 99
+    seeders:
+      default_value: 99
+    leechers:
+      default_value: 99
+    downloadvolumefactor:
+      default_value: 0
+    uploadvolumefactor:
+      default_value: 1
+    free_deadline:
+      default_value: "{{max_time}}"
+      default_value_format: '%Y-%m-%d %H:%M:%S.%f'
+    description:
+      selector: td.title > span > a[href^="/t/"]
+    title:
+      text: "{{ fields['description'] }}"
+search:
+  paths:
+    - path: /
+      categories: [ 1 ]
+  query:
+    term: "{{query.keyword}}"
+
+torrents:
+  list:
+    selector: div.container > table.table.table-hover.table-condensed.post-index > tr
+  fields:
+    id:
+      selector: td.title > span > a[href^="/t/"]
+      attribute: href
+      filters:
+        - name: re_search
+          args: [ '\d+', 0 ]
+    category:
+      default_value: 1
+    details:
+      selector: td.title > span > a[href^="/t/"]
+      attribute: href
+    download:
+      selector: td.action > a[href^="/t/"]
+      attribute: href
+    size:
+      selector: td.size
+    grabs:
+      default_value: 99
+    seeders:
+      default_value: 99
+    leechers:
+      default_value: 99
+    downloadvolumefactor:
+      default_value: 0
+    uploadvolumefactor:
+      default_value: 1
+    free_deadline: 
+      default_value: "{{max_time}}"
+      default_value_format: '%Y-%m-%d %H:%M:%S.%f'
+    description:
+      selector: td.title > span > a[href^="/t/"]
+    title:
+      text: "{{ fields['description'] }}"

--- a/sites/audiences.yml
+++ b/sites/audiences.yml
@@ -176,9 +176,13 @@ torrents:
           args: [ '\d+-\d+-\d+ \d+:\d+:\d+', 0 ]
         - name: dateparse
           args: "%Y-%m-%d %H:%M:%S"
-    description:
+    subject:
       selector: td.embedded
       contents: -1
+    tags:
+      selectors: td.embedded > span.tags
+    description:
+      text: "{% if fields['tags']%}{{ fields['subject']+' '+fields['tags']|join(' ') }}{% else %}{{ fields['subject'] }}{% endif %}"
     minimumratio:
       case:
         img.hitandrun: 1

--- a/sites/hdhome.yml
+++ b/sites/hdhome.yml
@@ -217,6 +217,10 @@ torrents:
           args: [ '\d+-\d+-\d+ \d+:\d+:\d+', 0 ]
         - name: dateparse
           args: "%Y-%m-%d %H:%M:%S"
-    description:
+    subject:
       selector: td:nth-child(2) > table > tr > td.embedded
       contents: -1
+    tags:
+      selectors: td.embedded > span.tags
+    description:
+      text: "{% if fields['tags']%}{{ fields['subject']+' '+fields['tags']|join(' ') }}{% else %}{{ fields['subject'] }}{% endif %}"

--- a/sites/hdsky.yml
+++ b/sites/hdsky.yml
@@ -185,12 +185,16 @@ torrents:
           args: [ '\d+-\d+-\d+ \d+:\d+:\d+', 0 ]
         - name: dateparse
           args: "%Y-%m-%d %H:%M:%S"
-    description:
+    tags:
+      selectors: td.embedded > span.optiontag
+    subject:
       selector: td:nth-child(2) > table > tr > td.embedded
       remove: img,a,b,span
       filters:
         - name: replace
           args: [ "[优惠剩余时间：]","" ]
+    description:
+      text: "{% if fields['tags']%}{{ fields['subject']+' '+fields['tags']|join(' ') }}{% else %}{{ fields['subject'] }}{% endif %}"
 
 detail:
   item:

--- a/sites/lemonhd.yml
+++ b/sites/lemonhd.yml
@@ -170,17 +170,15 @@ torrents:
     downloadvolumefactor:
       case:
         'div[style^="padding-left"] > span[title]': 0
-        #        img.pro_free2up: 0
-        #        img.pro_50pctdown: 0.5
-        #        img.pro_50pctdown2up: 0.5
-        #        img.pro_30pctdown: 0.3
         "*": 1
     uploadvolumefactor:
       case:
-        #        img.pro_50pctdown2up: 2
-        #        img.pro_free2up: 2
-        #        img.pro_2up: 2
         "*": 1
-    description:
+    subject:
       selectors: td:nth-child(3) > div
       index: 1
+    tags:
+      selectors: td:nth-child(3) > span.tag
+    description:
+      text: "{% if fields['tags']%}{{ fields['subject']+' '+fields['tags']|join(' ') }}{% else %}{{ fields['subject'] }}{% endif %}"
+    


### PR DESCRIPTION
新增ACG站点适配。url:https://acg.rip 。仅支持动漫分类搜索及下载。
修复观众、家园、天空、柠檬不抓取种子标签的问题。现在可以在搜索结果里看到站点种子标签了，主要增强程序识别种子的中字标签。